### PR TITLE
Updates for full install from initrd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,16 +1,16 @@
 dnl
 dnl configure.ac - autoconf script for tegra-sysinstall
 dnl
-dnl Copyright (c) 2019, 2020 Matthew Madison
+dnl Copyright (c) 2019-2021, Matthew Madison
 dnl
-AC_INIT([tegra-sysinstall], [1.4.0])
+AC_INIT([tegra-sysinstall], [1.5.0])
 AC_DEFINE([TEGRA_SYSINSTALL_VERSION_MAJOR], [1], [Major version])
-AC_DEFINE([TEGRA_SYSINSTALL_VERSION_MINOR], [4], [Minor version])
+AC_DEFINE([TEGRA_SYSINSTALL_VERSION_MINOR], [5], [Minor version])
 AC_DEFINE([TEGRA_SYSINSTALL_VERSION_MAINT], [0], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([
-Copyright (c) 2019, 2020 Matthew Madison
+Copyright (c) 2019-2021, Matthew Madison
 ])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/lib/tools-common.in
+++ b/lib/tools-common.in
@@ -443,37 +443,27 @@ secure_boot_enabled() {
 #
 update_bootloader() {
     local updlog=`mktemp /tmp/bup.log.XXXXXX`
-    local tmpconf
-    local fs rc d
-    local mounts=(/dev /sys /run /usr/bin /usr/lib /lib)
+    local fs rc
+    local mounts=(/dev /sys /run)
+    local options
 
     rc=0
-    if [ -e "$1/etc/nv_boot_control.template" ]; then
-	local boardspec=$(tegra-boardspec 2>/dev/null)
-	local devtype=$(cat "$1/usr/share/tegra-boot-tools/machine-name.conf")
-	tmpconf=$(mktemp /tmp/bootctrl.XXXXXX)
-	if [ -z "$boardspec" ]; then
-	    echo "ERR: cannot retrieve boardspec for nv_boot_control.conf generation" >&2
-	    return 1
-	fi
-	[ -n "$devtype" ] || devtype=$(cat "$1/etc/hostname")
-	if [ -z "$devtype" ]; then
-	    echo "ERR: cannot retrieve machine name for nv_boot_control.conf generation" >&2
-	    return 1
-	fi
-	sed -e"s,@TNSPEC@,${boardspec}-${devtype}-mmcblk0p1," $1/etc/nv_boot_control.template > "$tmpconf"
-	export NV_BOOT_CONTROL="$tmpconf"
-    elif [ -e "$1/etc/nv_boot_control.conf" ]; then
-	export NV_BOOT_CONTROL="$1/etc/nv_boot_control.conf"
-    fi
     if [ "$INITIAL_SETUP" = "yes" ]; then
-	tegra-bootloader-update --initialize "$1/opt/ota_package/bl_update_payload" || rc=1
-    else
-	tegra-bootloader-update "$1/opt/ota_package/bl_update_payload" || rc=1
+        options="--initialize"
     fi
-
-    unset NV_BOOT_CONTROL
-    [ -z "$tmpconf" ] || rm -f "$tmpconf"
+    mount -t proc proc "$1/proc"
+    for fs in ${mounts[@]}; do
+	mount --bind $fs "$1$fs"
+    done
+    if ! chroot "$1" /usr/bin/tegra-bootloader-update $options /opt/ota_package/bl_update_payload 2>&1 >"$updlog"; then
+	echo "ERR: bootloader update failed, log follows:" >&2
+	cat "$updlog" >&2
+	rc=1
+    fi
+    for fs in ${mounts[@]}; do
+	umount "$1$fs"
+    done
+    umount "$1/proc"
     return $rc
 }
 

--- a/lib/tools-common.in
+++ b/lib/tools-common.in
@@ -775,7 +775,7 @@ set_url() {
     local varname="$1"
     local value="$2"
     local default="$3"
-    local disposition="${4:required}"
+    local disposition="${4:-required}"
     local rc=0
 
     eval $varname=""

--- a/lib/tools-common.in
+++ b/lib/tools-common.in
@@ -67,6 +67,9 @@ identify_platform_setup() {
 	    esac
 	    continue
 	fi
+	if [ "$MOUNTPOINT" = "/" ]; then
+	    found_rootfs=yes
+	fi
 	if [ "$PKNAME" = "$rootfsdev" -a -n "$PARTLABEL" ]; then
 	    local ptnfile="/sys/block/$PKNAME/$NAME/partition"
 	    EMMC_PARTITIONS[$PARTLABEL]="$NAME"
@@ -88,6 +91,10 @@ identify_platform_setup() {
 	    fi
 	fi
     done < <(lsblk -P -o MOUNTPOINT,NAME,PKNAME,PARTLABEL,TYPE)
+
+    if [ "$INITIAL_SETUP" != "yes" -a -z "$found_rootfs" ]; then
+	INITIAL_SETUP=yes
+    fi
 
     if [ "$INITIAL_SETUP" = "yes" ]; then
 	INSTALLTO="0 1"
@@ -324,35 +331,29 @@ partition_available() {
 # Re-partitions a GPT disk
 repartition_gpt_device() {
     local pftmp=`mktemp -q`
-    local name size type guid file startpos curpos endpos partnum typearg
+    local name size type guid file startpos partnum typearg
     echo "Re-partitioning device $1"
     if [ ! -b "$1" ]; then
 	echo "ERR: $1 is not a block device" >&2
 	return 1
     fi
-    if ! sgdisk "$1" --disk-guid=R --clear >/dev/null 2>&1; then
-	echo "ERR: could not clear partition table on $1" >&2
+    if ! sgdisk "$1" --disk-guid=R --zap-all >/dev/null 2>&1; then
+	echo "ERR: could not zap partition table on $1" >&2
 	return 1
     fi
-    grep -v '^[[:space:]]*#' "$2" >$pftmp
-    curpos=0
-    partnum=0
-    while IFS=, read name size type guid file startpos; do
-	if [ -z "$name" -o -z "$size" ]; then
+    egrep -v '^[[:space:]]*#' "$2" >$pftmp
+    while IFS=, read partnum name size type guid file startpos; do
+	if [ -z "partnum" -o -z "$name" -o -z "$size" ]; then
 	    continue
 	fi
-	echo -n " -- creating partition $name... "
+	echo -n " -- creating partition $partnum ($name)... "
 	if [ -z "$startpos" ]; then
 	    startpos=0
 	fi
-	if [ $startpos -ne 0 ]; then
-	    curpos=$startpos
-	fi
-	partnum=$(expr $partnum + 1)
 	if [ -n "$type" ]; then
 	    typearg="--typecode=$partnum:$type"
 	else
-	    typearg=""
+	    typearg="--typecode=$partnum:0700"
 	fi
 	if [ -n "guid" ]; then
 	    guidarg="--partition-guid=$partnum:$guid"
@@ -366,13 +367,11 @@ repartition_gpt_device() {
 		return 1
 	    fi
 	else
-	    endpos=$(expr $curpos + $size - 1)
-	    if ! sgdisk "$1" -a 1 --new=$partnum:$curpos:$endpos $typearg $guidarg -c "$partnum:$name" >/dev/null 2>&1; then
+	    if ! sgdisk "$1" -a 1 --new=$partnum:$startpos:+$size $typearg $guidarg -c "$partnum:$name" >/dev/null 2>&1; then
 		echo "[FAIL]"
 		rm -f "$pftmp"
 		return 1
 	    fi
-	    curpos=$(expr $endpos + 1)
 	fi
 	echo "[OK]"
     done < "$pftmp"
@@ -450,6 +449,27 @@ update_bootloader() {
     rc=0
     if [ "$INITIAL_SETUP" = "yes" ]; then
         options="--initialize"
+	echo -n "Clearing boot device"
+	if [ -b "/dev/mtdblock0" ]; then
+	    echo -n " /dev/mtdblock0..."
+	    dd if=/dev/zero of=/dev/mtdblock0 bs=65536 count=512 >/dev/null 2>&1 || rc=1
+	else
+	    if [ -b "/dev/mmcblk0boot0" ]; then
+		echo -n " /dev/mmcblk0boot0..."
+		echo "0" > /sys/block/mmcblk0boot0/force_ro
+		dd if=/dev/zero of=/dev/mmcblk0boot0 bs=8192 count=512 >/dev/null 2>&1 || rc=1
+	    fi
+	    if [ -b "/dev/mmcblk0boot1" ]; then
+		echo -n " /dev/mmcblk0boot1..."
+		echo "0" > /sys/block/mmcblk0boot1/force_ro
+		dd if=/dev/zero of=/dev/mmcblk0boot0 bs=8192 count=512 >/dev/null 2>&1 || rc=1
+	    fi
+	fi
+	if [ $rc -ne 0 ]; then
+	    echo " [FAIL]"
+	    return $rc
+	fi
+	echo " [OK]"
     fi
     mount -t proc proc "$1/proc"
     for fs in ${mounts[@]}; do
@@ -507,44 +527,43 @@ make_fake_parttable() {
 
 # initialize_devices
 #
-# The TX2 early-stage boot code verifies the entire boot chain,
-# including boot code located in normal partitions in the eMMC,
-# through a table created from the partition layout XML file
-# used by NVIDIA's flashing tools.
+# Reformat the eMMC (or SDcard) with a partition table that
+# is generated from the flash layout XML file.
 #
-# For this reason, we cannot repartition it here, otherwise
-# we will likely render the device unbootable. However, we
-# can do some cleanup of the main GPT that was created
-# at flash time, bringing it up to GPT specs and removing
-# the 'unused' partition that was required for the NVIDIA
-# flash tools.
+# IMPORTANT: on some of the Jetson devices, you must specify
+# 16896 as the size of the primary GPT in your flash layout
+# in order for the NVIDIA bootloaders to be compatible with
+# the full-size GPT created by the Linux-based tools. Otherwise,
+# the target will be unbootable.
+#
 initialize_devices() {
     local rootfsdev="/dev/$ROOTFSDEVTYPE$ROOTFSDEVNUM"
     local part needprobe
 
     if [ "$INSTALLTO" = "0 1" -a -s "@datadir@/tegra-sysinstall/partition_table" ]; then
-	echo "ERROR: repartitioning of the eMMC is not supported" >&2
-    fi
-
-    #
-    # Delete the extra partition created at flash time.
-    #
-    if [ -n "${EMMC_PARTITIONS[unused]}" ]; then
-	echo -n "Removing unused partition..."
-	if ! sgdisk $rootfsdev --delete=${PARTINDEX[unused]} >/dev/null 2>&1; then
-	    echo "[FAIL]"
-	    echo "ERR: could not delete 'unused' partition" >&2
-	    return 1
+	echo "Re-partitioning the eMMC..."
+	repartition_gpt_device /dev/$ROOTFSDEVTYPE$ROOTFSDEVNUM "@datadir@/tegra-sysinstall/partition_table"
+    else
+	#
+	# Delete the extra partition created at flash time.
+	#
+	if [ -n "${EMMC_PARTITIONS[unused]}" ]; then
+	    echo -n "Removing unused partition..."
+	    if ! sgdisk $rootfsdev --delete=${PARTINDEX[unused]} >/dev/null 2>&1; then
+		echo "[FAIL]"
+		echo "ERR: could not delete 'unused' partition" >&2
+		return 1
+	    fi
+	    needprobe="yes"
+	    echo "[OK]"
 	fi
-	needprobe="yes"
-	echo "[OK]"
-    fi
-    resize_gpt "$rootfsdev" needprobe || return 1
+	resize_gpt "$rootfsdev" needprobe || return 1
 
-    if [ "$needprobe" = "yes" ]; then
-	reprobe_rootfsdev
-	identify_platform_setup || return 1
-	needprobe=
+	if [ "$needprobe" = "yes" ]; then
+	    reprobe_rootfsdev
+	    identify_platform_setup || return 1
+	    needprobe=
+	fi
     fi
 
     if ! secure_boot_enabled; then
@@ -552,6 +571,7 @@ initialize_devices() {
 	return 0
     fi
 
+    # In case the flash layout doesn't name these with the 'crypt-' prefix
     for part in APP APP_b DATA; do
 	if [ -z "${CRYPT_PARTITIONS[$part]}" -a -z "${EMMC_PARTITIONS[crypt-$part]}" ]; then
 	    if [ "$part" = "DATA" ]; then
@@ -668,9 +688,9 @@ unmount_storage_partitions() {
 remove_installer_partition() {
     local rootfsdev="/dev/$ROOTFSDEVTYPE$ROOTFSDEVNUM"
     if [ -z "${EMMC_PARTITIONS[INSTALLER]}" ]; then
-	echo "WARN: no INSTALLER partition found" >&2
 	return 0
     fi
+    echo "Removing INSTALLER partition and rebooting..."
     if ! sgdisk $rootfsdev --delete=${PARTINDEX[INSTALLER]} >/dev/null 2>&1; then
 	echo "ERR: could not delete INSTALLER partition" >&2
 	return 0

--- a/src/tegra-sysinstall.in
+++ b/src/tegra-sysinstall.in
@@ -131,7 +131,4 @@ else
 fi
 
 cleanup_and_exit
-if [ "$INITIAL_SETUP" = "yes" ]; then
-    echo "Installation complete.  Removing INSTALLER partition and rebooting..."
-    remove_installer_partition
-fi
+[ "$INITIAL_SETUP" != "yes" ] || remove_installer_partition


### PR DESCRIPTION
* Install now wipes and re-partitions the eMMC as part of initial installation
* Coupled with the latest version of [tegra-boot-tools](https://github.com/OE4T/tegra-boot-tools), which re-partitions the boot device, you can have an installer which can be booted from one version of L4T and installs another that uses a different flash layout
