### PR TITLE
configure.ac: Add --with-key-retrieval-command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,5 +26,11 @@ AC_ARG_WITH([partition-alignment],
 	[], [with_partition_alignment=1])
 AC_SUBST([PARTALIGN], [$with_partition_alignment])
 
+AC_ARG_WITH([key-retrieval-command],
+	AS_HELP_STRING([--with-key-retrieval-command=CMD],
+	[command to retrieve key which is used as LUKS passphrase @<:@default="keystoretool -p"@:>@]),
+	[], [with_key_retrieval_command="keystoretool -p"])
+AC_SUBST([KEY_RETRIEVAL_CMD], [$with_key_retrieval_command])
+
 AC_CONFIG_FILES(Makefile src/tegra-sysinstall src/tegra-sysinstall-menu lib/tools-common lib/menu-common)
 AC_OUTPUT

--- a/lib/tools-common.in
+++ b/lib/tools-common.in
@@ -733,7 +733,7 @@ initialize_devices() {
     local fakept=`mktemp -q`
     if make_fake_parttable $fakept; then
 	local ppdir=`mktemp -q -d /run/setup-pp.XXXXXX`
-	keystoretool -p > $ppdir/passphrase
+	@KEY_RETRIEVAL_CMD@ > $ppdir/passphrase
 	if ! create_luks_partitions $ppdir $fakept; then
 	    rm -rf $ppdir
 	    return 1


### PR DESCRIPTION
Add a "knob" to allow swapping out the default "keystoretool -p" command for retrieving the LUKS passphrase.

This allows for example "${sbindir}/luks-srv-app --get-unique-pass --context-string=@DISK_ENCRYPTION_CONTEXT@" to be used instead.

Also replace "keystore -p" with @KEY_RETRIEVAL_CMD@ in lib/tools-common.in to allow for AC_SUBST to do the expected substitution.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>